### PR TITLE
Implement allowed wallets feature.

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ This command will automatically publish the `WalletEnums.php` file into your app
 
 ## Updating
 
-If updating from version `<= 1.0.3`, new migration and config files have been added to support the new [Transaction Info Feature](#transaction-info)
+If updating from version `<= 1.0.3`, new migration and config files have been added to support the new [Transaction Notes Feature](#transaction-info)
 
 Follow the [Installation](#installation) Steps 2 and 3 to update your migrations.
 
@@ -108,7 +108,7 @@ If the balance in `wallet_1` is 10 and the balance in `wallet_2` is 20, and you 
 ### Deposit
 
 ```php
-deposit(type: 'wallet_1', amount: 123.45, notes: null)
+deposit(type: string, amount: float|int, notes: string null)
 ```
 
 Deposit funds into `wallet_1`
@@ -137,19 +137,19 @@ LaravelPayPocket::deposit($user, 'wallet_1', 123.45);
 
 Note: `wallet_1` and `wallet_2` must already be defined in the `WalletEnums`.
 
-#### Transaction Info ([#8][i8])
+#### Transaction Notes ([#8][i8])
 
 In a case where you want to enter descriptions for a particular transaction, the `$notes` param allows you to provide information about why a transaction happened.
 
 ```php
 $user = auth()->user();
-$user->deposit('wallet_1', 67.89, 'You ordered pizza.');
+$user->deposit('wallet_1', 67.89, 'You sold pizza.');
 ```
 
 ### Pay
 
 ```php
-pay(amount: 12.34, notes: null)
+pay(amount: int, allowedWallets: array [], notes: string null)
 ```
 
 Pay the value using the total combined balance available across all allowed wallets
@@ -166,6 +166,28 @@ use HPWebdeveloper\LaravelPayPocket\Facades\LaravelPayPocket;
 
 $user = auth()->user();
 LaravelPayPocket::pay($user, 12.34);
+```
+
+By default the sytem will attempt to pay using all available wallets unless the `allowedWallets` param is provided.
+
+#### Allowed Wallets ([#8][i8])
+
+Sometimes you want to mark certain wallets as allowed so that when the `pay()` method is called, the system does not attempt to charge other wallets, a possible use case is an escrow system, the `$allowedWallets` param of the pay method allows you to do just that.
+
+```php
+$user = auth()->user();
+$user->pay(12.34, ['wallet_1']);
+```
+
+When the `$allowedWallets` param is provided and is not an empty array, the system would attempt to charge only the wallets specified in the array.
+
+#### Transaction Notes ([#8][i8])
+
+In a case where you want to enter descriptions for a particular transaction, the `$note` param allows you to provide information about why a transaction happened.
+
+```php
+$user = auth()->user();
+$user->pay(12.34, [], 'You ordered pizza.');
 ```
 
 ### Balance

--- a/src/Interfaces/WalletOperations.php
+++ b/src/Interfaces/WalletOperations.php
@@ -10,7 +10,7 @@ interface WalletOperations
 
     public function hasSufficientBalance($value): bool;
 
-    public function pay(int|float $orderValue, ?string $notes = null);
+    public function pay(int|float $orderValue, array $allowedWallets = [], ?string $notes = null): void;
 
     public function deposit(string $type, int|float $amount, ?string $notes = null): bool;
 }

--- a/src/Services/PocketServices.php
+++ b/src/Services/PocketServices.php
@@ -4,14 +4,14 @@ namespace HPWebdeveloper\LaravelPayPocket\Services;
 
 class PocketServices
 {
-    public function deposit($user, $type, $amount, $notes = null)
+    public function deposit($user, $type, $amount, $notes = null): bool
     {
         return $user->deposit($type, $amount, $notes);
     }
 
-    public function pay($user, $orderValue, $notes = null)
+    public function pay($user, $orderValue, array $allowedWallets = [], ?string $notes = null): void
     {
-        return $user->pay($orderValue, $notes);
+        $user->pay($orderValue, $allowedWallets, $notes);
     }
 
     public function checkBalance($user)

--- a/src/Traits/HandlesPayment.php
+++ b/src/Traits/HandlesPayment.php
@@ -25,16 +25,20 @@ trait HandlesPayment
             $walletsInOrder = $this->wallets()->whereIn('type', $this->walletsInOrder())->get();
 
             /**
-             * @param string $wallet
+             * @param string|\App\Enums\WalletEnums
              * @return bool $useWallet
              * */
-            $useWallet = fn ($wallet) => count($allowedWallets) < 1 || in_array($wallet, $allowedWallets);
+            $useWallet = function (string|\App\Enums\WalletEnums $wallet) use ($allowedWallets) {
+                return count($allowedWallets) < 1 ||
+                       in_array($wallet, $allowedWallets) ||
+                       in_array($wallet->value, $allowedWallets);
+            };
 
             /**
              * @var BalanceOperation $wallet
              */
             foreach ($walletsInOrder as $wallet) {
-                if (! $wallet || ! $wallet->hasBalance() || !$useWallet($wallet->type->value)) {
+                if (! $wallet || ! $wallet->hasBalance() || !$useWallet($wallet->type)) {
                     continue;
                 }
 


### PR DESCRIPTION
This PR allows wallets to be marked as `allowed` during a `pay()` transaction, this will prevent the system from attempting to charge from wallets which have not been added to the allowed array of wallets, a possible use case for this is for an escrow system where you may want to restrict the outflow of funds from the escrow wallet before a deal is closed.