### PR TITLE
Fix Wallet type validation bug

### DIFF
--- a/Enums/WalletEnums.php
+++ b/Enums/WalletEnums.php
@@ -10,8 +10,16 @@ enum WalletEnums: string
     /**
      * Check if a given value is a valid enum case.
      */
-    public static function isValid(string $type): bool
+    public static function isValid(string|WalletEnums $type): bool
     {
+        if (is_string($type)) {
+            try {
+                $type = WalletEnums::from($type);
+            } catch (\ValueError $th) {
+                return false;
+            }
+        }
+
         foreach (self::cases() as $case) {
             if ($case->value === $type) {
                 return true;


### PR DESCRIPTION
The `getWalletBalanceByType()` method of the `HasWallet` trait requires a string parameter as wallet type and does checks wallet validity using `WalletEnums::isValid($walletType)` which also requires a string parameter, the `isValid` method of the `WalletEnums` enum checks the wallet vality by looping through `self::cases()` and checking for a match `self::cases()` is an array of WalletEnum case instances and not strings, meaning a match will never be found, this pull request fixes that by allowing the `$type` parameter to be either a string or an instance of WalletEnums and then checking if it's a string then converting it to the appropriete case using `WalletEnums::from($type)`.